### PR TITLE
Fix dependency hell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: scala
+scala: 2.12.4
+jdk: oraclejdk8
+dist: trusty
+sudo: false
+
+script: 
+  - sbt test lwc/assembly
+
+before_deploy:
+  - chmod +x scripts/*
+  - . ./scripts/version
+  - . ./scripts/travis_tag
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "Aeqn0XLb0iFbnTWBatFiHaLb7J0TaBw6ry69MjriF53rhHbyZvXE4B1nUO9/li+QYeEXR7bf/UHmPGX1pst8TFtNEhtzRoAlxn8z8z698J5ymKWcVXGAJUO7gv1QCRxCFusBR0BxMZf/lNxjYOjOCOs2EwkYK2VU3uvuo4LviHKX8Ggm1g/pvHPjT0orb3NzFFMi/JNLjwGLj/8RkNqeibHVb07aM1S+Yvh5QGRTd1oJwV6h2XPhyCl1PoywnU7jt/vHs0HOU5OXG+oJ0gtSZ3SjYJajN3/thbLzQOAClrxaoF7YGw8uPQa1vxCqNq9LOJwqBI2zcU5CbiCKP0vOjz+ECOWPaF5yTi8QaQXi5Zc8F5iHHbXSENVwffwELV40NlNMi6WOBVK4qyROfQjfRD9KYtwUTtBCjnvkBY+618BtrTFuE0VqsrMiobMItKNl/7NPfsiI00Rat3seqxPWhbSGvEV4Eyx0RB+THSnMeTgDeuRJVahazYFCpbq0l628XZB90h7LHq3qcijnZQLC2HLC+1x/z8i4r5JwialC8+Tl8q9ZuO6n9nNKGVWw5Wt2WK7JYWq/2J1HTFf+lVp9OaGi7wMfTO48g4nrnQ6V5H5SqyOfL7ofgt6ktPcBh+vKqTvHlXoezWLlT9r8UFrRSFzdD/hU+pQp6eCXcf2I2z8="
+  #file_glob: true
+  file:
+    - runner/target/scala-2.12/quasar-s3-assembly-$VERSION.jar
+  skip_cleanup: true
+  script: 
+    - ./scripts/version
+    - ./scripts/update_nix_file
+  on:
+    tags: false
+    #all_branches: true
+    # Omit tagged builds and publish on master and backport/*
+    #condition: $TRAVIS_TAG = '' && ($TRAVIS_BRANCH == "master" || $TRAVIS_BRANCH == backport/*)
+
+after_deploy:
+  - ./scripts/update_nix_file
+
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/ # don't redundantly build tags
+
+cache:
+  directories:
+    - $HOME/.coursier/cache
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+
+before_cache:
+  - find "$HOME/.sbt/" -name '*.lock' -print0 | xargs -0 rm
+  - find "$HOME/.ivy2/" -name 'ivydata-*.properties' -print0 | xargs -0 rm
+

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,11 @@ lazy val buildSettings = commonBuildSettings ++ Seq(
 
   logBuffered in Test := isTravisBuild.value,
 
-  console := { (console in Test).value }) // console alias test:console
+  console := { (console in Test).value }, // console alias test:console
+  assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+    case x => MergeStrategy.first
+  })
 
 val targetSettings = Seq(
   target := {
@@ -157,7 +161,6 @@ def isolatedBackendSettings(classnames: String*) = Seq(
 lazy val isCIBuild               = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
 lazy val isIsolatedEnv           = settingKey[Boolean]("True if running in an isolated environment")
 lazy val exclusiveTestTag        = settingKey[String]("Tag for exclusive execution tests")
-lazy val sparkDependencyProvided = settingKey[Boolean]("Whether or not the spark dependency should be marked as provided. If building for use in a Spark cluster, one would set this to true otherwise setting it to false will allow you to run the assembly jar on it's own")
 
 lazy val isolatedBackends =
   taskKey[Seq[(String, Seq[File])]]("Global-only setting which contains all of the classpath-isolated backends")

--- a/lwc/src/main/scala/fs2conversion.scala
+++ b/lwc/src/main/scala/fs2conversion.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spinoco.scalaz.stream
+
+import slamdata.Predef.{Stream => _, _}
+import scala.Predef.identity
+
+import fs2._
+
+import scalaz.concurrent.{Actor, Task}
+import scalaz.stream.Process
+import scala.language.higherKinds
+import scalaz.{-\/, \/, \/-}
+import shims._
+
+// ALL of the code below has been converted from fs2 0.9 to 0.10
+// from a gist of code originally written by Pavel Chlupacek (@pchlupacek on github)
+// and shared with the community as https://gist.github.com/pchlupacek/989a2801036a9441da252726a1b4972d
+object fs2Conversion {
+
+  def processToFs2[A](in:Process[Task,A]): Stream[Task,A] = Stream.suspend {
+    import impl._
+    val actor = syncActor[AttemptT, AttemptT, A]
+
+    (Process.eval(Task.async[Boolean]{ cb => actor ! RegisterPublisher[AttemptT](cb) }) ++
+    in.evalMap { a => Task.async[Boolean]{ cb => actor ! OfferChunk[AttemptT,A](Chunk.singleton(a), cb) } }
+    .takeWhile(identity))
+    .run.unsafePerformAsync {
+      case \/-(_) =>   actor ! PublisherDone(None)
+      case -\/(rsn) => actor ! PublisherDone(Some(rsn))
+    }
+
+    // stream from an actor
+    @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+    def go:fs2.Stream[Task,A] = {
+      Stream.eval(Task.async[Option[Chunk[A]]]{ cb =>
+        actor ! RequestChunk[AttemptT,A](cb)
+      }).flatMap {
+        case None => Stream.empty // done
+        case Some(chunk) => Stream.chunk(chunk) ++ go
+      }
+    }
+
+    go
+    .handleErrorWith { rsn =>
+      Stream.eval_(Task.delay { actor ! SubscriberDone(Some(rsn)) }) ++ Stream.raiseError(rsn)
+    }
+    .onFinalize {
+      Task.delay(actor ! SubscriberDone(None))
+    }
+  }
+
+
+
+  private object impl {
+
+    type AttemptT[+A] = Throwable \/ A
+
+    sealed trait Attempt[F[+_]] {
+      def success[A](a:A):F[A]
+      val continue:F[Boolean] = success(true)
+      val stop:F[Boolean] = success(false)
+      def failure(rsn:Throwable):F[Nothing]
+      def fromResult(result:Option[Throwable]):F[Boolean] = result.map(failure).getOrElse(stop)
+    }
+
+    object Attempt {
+      implicit val processInstance: Attempt[AttemptT]= new Attempt[AttemptT] {
+        def success[A](a: A): AttemptT[A] = \/-(a)
+        def failure(rsn: Throwable): AttemptT[Nothing] = -\/(rsn)
+      }
+
+    }
+
+    final case class RegisterPublisher[F[+_]](cb: F[Boolean] => Unit) extends M[F,scala.Nothing,Nothing]
+    final case class RequestChunk[F[+_], A](cb: F[Option[Chunk[A]]] => Unit) extends M[scala.Nothing,F,A]
+    final case class OfferChunk[F[+_], A](chunk:Chunk[A], cb: F[Boolean] => Unit) extends M[F,scala.Nothing,A]
+    final case class SubscriberDone(result:Option[Throwable]) extends M[scala.Nothing,scala.Nothing,Nothing]
+    final case class PublisherDone(result:Option[Throwable]) extends M[scala.Nothing,scala.Nothing,Nothing]
+
+    sealed trait M[+FIn[+_], +FOut[+_] ,+A]
+
+    @SuppressWarnings(Array("org.wartremover.warts.Var"))
+    def syncActor[FIn[+_], FOut[+_], A](implicit FIn:Attempt[FIn], FOut:Attempt[FOut]): Actor[M[FIn,FOut,A]] = {
+
+      var upReady:Option[FIn[Boolean] => Unit] = None
+      var requestReady:Option[FOut[Option[Chunk[A]]] => Unit] = None
+      var done:Option[Option[Throwable]] = None
+
+      Actor.actor[M[FIn, FOut, A]]({
+        case register:RegisterPublisher[FIn @ unchecked] =>
+          if (requestReady.nonEmpty) register.cb(FIn.continue)
+          else upReady = Some(register.cb)
+
+        case request:RequestChunk[FOut @unchecked,A @unchecked] =>
+          done match {
+            case None => requestReady = Some(request.cb) ; upReady.foreach { cb => cb(FIn.continue) } ; upReady = None
+            case Some(None) => request.cb(FOut.success(None))
+            case Some(Some(rsn)) => request.cb(FOut.failure(rsn))
+          }
+
+        case offer:OfferChunk[FIn @unchecked ,A @unchecked] =>
+          done match {
+            case None => requestReady match {
+              case Some(rcb) => rcb(FOut.success(Some(offer.chunk))) ; upReady = Some(offer.cb) ; requestReady = None
+              case None =>
+                val rsn = new Throwable(s"Downstream not ready, while requesting data : ${offer.chunk}")
+                done = Some(Some(rsn))
+                offer.cb(FIn.failure(rsn))
+            }
+
+            case Some(result) => offer.cb(FIn.fromResult(result))
+          }
+
+        case SubscriberDone(result) =>
+          upReady.foreach { cb => cb(FIn.fromResult(result)) }
+          upReady = None
+          done = done orElse Some(result)
+
+        case PublisherDone(result) =>
+          requestReady.foreach { cb => result match {
+            case None => cb(FOut.success(None))
+            case Some(rsn) => cb(FOut.failure(rsn))
+          }}
+          requestReady = None
+          done = done orElse Some(result)
+
+      })(scalaz.concurrent.Strategy.Sequential)
+
+    }
+
+  }
+
+}

--- a/lwc/src/main/scala/quasar/physical/parsing/ParsingPipe.scala
+++ b/lwc/src/main/scala/quasar/physical/parsing/ParsingPipe.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// from circe/circe-fs2 0.9.1
+
+package quasar.physical.s3.parsing
+
+import slamdata.Predef.{Seq => _, _}
+import scala.collection.Seq
+
+import _root_.fs2.{ Chunk, Handle, Pipe, Pull, Stream }
+import _root_.jawn.{ AsyncParser, ParseException }
+import io.circe.{ Json, ParsingFailure }
+import io.circe.jawn.CirceSupportParser
+
+private[parsing] abstract class ParsingPipe[F[_], S] extends Pipe[F, S, Json] {
+  protected[this] def parsingMode: AsyncParser.Mode
+
+  protected[this] def parseWith(parser: AsyncParser[Json])(in: S): Either[ParseException, Seq[Json]]
+
+  private[this] final def makeParser: AsyncParser[Json] = CirceSupportParser.async(mode = parsingMode)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  private[this] final def doneOrLoop[A](p: AsyncParser[Json])(h: Handle[F, S]): Pull[F, Json, Unit] =
+    h.receive1 {
+      case (s, h) => parseWith(p)(s) match {
+        case Left(error) =>
+          Pull.fail(ParsingFailure(error.getMessage, error))
+        case Right(js) =>
+          Pull.output(Chunk.seq(js)) >> doneOrLoop(p)(h)
+      }
+    }
+
+  final def apply(s: Stream[F, S]): Stream[F, Json] = s.pull(doneOrLoop(makeParser))
+}

--- a/lwc/src/main/scala/quasar/physical/parsing/package.scala
+++ b/lwc/src/main/scala/quasar/physical/parsing/package.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// from circe/circe-fs2 0.9.1
+
+package quasar.physical.s3
+
+import slamdata.Predef.{Seq => _, _}
+import scala.collection.Seq
+
+import _root_.fs2.{ Chunk, Pipe, Stream }
+import _root_.fs2.pipe
+import _root_.jawn.{ AsyncParser, ParseException }
+import io.circe.{Decoder, Json}
+import io.circe.jawn.CirceSupportParser
+
+package object parsing {
+  final def stringArrayParser[F[_]]: Pipe[F, String, Json] = stringParser(AsyncParser.UnwrapArray)
+
+  final def stringStreamParser[F[_]]: Pipe[F, String, Json] = stringParser(AsyncParser.ValueStream)
+
+  final def byteArrayParser[F[_]]: Pipe[F, Byte, Json] = byteParser(AsyncParser.UnwrapArray)
+
+  final def byteStreamParser[F[_]]: Pipe[F, Byte, Json] = byteParser(AsyncParser.ValueStream)
+
+  final def byteArrayParserC[F[_]]: Pipe[F, Chunk[Byte], Json] = byteParserC(AsyncParser.UnwrapArray)
+
+  final def byteStreamParserC[F[_]]: Pipe[F, Chunk[Byte], Json] = byteParserC(AsyncParser.ValueStream)
+
+  final def stringParser[F[_]](mode: AsyncParser.Mode): Pipe[F, String, Json] = new ParsingPipe[F, String] {
+    protected[this] final def parseWith(p: AsyncParser[Json])(in: String): Either[ParseException, Seq[Json]] =
+      p.absorb(in)(CirceSupportParser.facade)
+
+    protected[this] val parsingMode: AsyncParser.Mode = mode
+  }
+
+  final def byteParserC[F[_]](mode: AsyncParser.Mode): Pipe[F, Chunk[Byte], Json] = new ParsingPipe[F, Chunk[Byte]] {
+    protected[this] final def parseWith(p: AsyncParser[Json])(in: Chunk[Byte]): Either[ParseException, Seq[Json]] =
+      p.absorb(in.toArray)(CirceSupportParser.facade)
+
+    protected[this] val parsingMode: AsyncParser.Mode = mode
+  }
+
+  final def byteParser[F[_]](mode: AsyncParser.Mode): Pipe[F, Byte, Json] = _.through(pipe.chunks).through(byteParserC(mode))
+
+  final def decoder[F[_], A](implicit decode: Decoder[A]): Pipe[F, Json, A] =
+    _.flatMap { json =>
+      decode(json.hcursor) match {
+        case Left(df) => Stream.fail(df)
+        case Right(a) => Stream.emit(a)
+      }
+    }
+}

--- a/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
@@ -16,21 +16,14 @@
 
 package quasar.physical.s3
 
-import quasar.Data
-import quasar.contrib.pathy._
 import quasar.fs.mount.ConnectionUri
 import quasar.mimir.{LightweightConnector, LightweightFileSystem}
 import slamdata.Predef._
 
-import fs2.Stream
-import org.http4s.client._
-import org.http4s.client.blaze._
-import org.http4s.{Method, Request, Status, Uri}
-import pathy.Path
+import org.http4s.client.blaze.PooledHttp1Client
+import org.http4s.Uri
 
 import scalaz._
-import scalaz.syntax.applicative._
-import scalaz.syntax.std.boolean._
 import scalaz.concurrent.Task
 
 object S3LWC extends LightweightConnector {
@@ -42,59 +35,7 @@ object S3LWC extends LightweightConnector {
     EitherT.rightT(Task.delay {
       val client = PooledHttp1Client()
       val \/-(httpUri) = Uri.fromString(uri.value)
-      (new S3FS(httpUri, client), client.shutdown)
+      (new S3LWFS(httpUri, client), client.shutdown)
     })
 
-}
-
-final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
-
-  implicit final class optApplyOps[B](self: B) {
-    def >+>[A](opt: Option[A], f: (B, A) => B): B = opt.fold(self)(f(self, _))
-  }
-
-  private def aPathToObjectPrefix(apath: APath): Option[String] = {
-    val pathPrinted = Path.posixCodec.printPath(apath)
-    // don't provide prefix if listing the top-level,
-    // otherwise drop the first /
-    (pathPrinted != Path.rootDir).option(pathPrinted.drop(1).replace("/", "%2F"))
-  }
-
-  def children(dir: ADir): Task[Option[Set[PathSegment]]] = {
-    val objectPrefix = aPathToObjectPrefix(dir)
-    val maxKeys = 100
-    val queryUri = ((uri / "") +?
-      ("max-keys", 1) +?
-      ("list-type", 2)) >+>[String]
-      (objectPrefix, _ +? ("prefix", _))
-    println(s"uri: $queryUri")
-    Task.suspend {
-      println(client.expect[String](queryUri).unsafePerformSync)
-      ???
-    }
-  }
-
-  def exists(file: AFile): Task[Boolean] = {
-    val objectPath = Path.posixCodec.printPath(file).drop(1)
-    Task.suspend {
-      val queryUri = uri / objectPath
-      val request = Request(uri = queryUri, method = Method.HEAD)
-      println(queryUri)
-      client.status(request).flatMap {
-        case Status.Ok => true.point[Task]
-        case Status.NotFound => false.point[Task]
-        case s => Task.fail(new Exception("Unexpected status $s"))
-      }
-    }
-  }
-
-  def streamingParse(stream: Stream[Task, String]): Stream[Task, Data] = {
-
-  }
-
-  def read(file: AFile): Task[Option[Stream[Task, Data]]] = {
-    val objectPath = Path.posixCodec.printPath(file).drop(1)
-    val queryUri = uri / objectPath
-    client.streaming(queryUri)(resp => resp.body)
-  }
 }

--- a/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
@@ -47,7 +47,7 @@ object S3LWC extends LightweightConnector {
 
 }
 
-final class S3FS(uri: Uri, client: Client) extends LightweightFileSystem {
+final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
 
   implicit final class optApplyOps[B](self: B) {
     def >+>[A](opt: Option[A], f: (B, A) => B): B = opt.fold(self)(f(self, _))
@@ -88,5 +88,13 @@ final class S3FS(uri: Uri, client: Client) extends LightweightFileSystem {
     }
   }
 
-  def read(file: AFile): Task[Option[Stream[Task, Data]]] = ???
+  def streamingParse(stream: Stream[Task, String]): Stream[Task, Data] = {
+
+  }
+
+  def read(file: AFile): Task[Option[Stream[Task, Data]]] = {
+    val objectPath = Path.posixCodec.printPath(file).drop(1)
+    val queryUri = uri / objectPath
+    client.streaming(queryUri)(resp => resp.body)
+  }
 }

--- a/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/S3LWC.scala
@@ -16,8 +16,9 @@
 
 package quasar.physical.s3
 
+import quasar.fs.FileSystemType
 import quasar.fs.mount.ConnectionUri
-import quasar.mimir.{LightweightConnector, LightweightFileSystem}
+import quasar.mimir.{LightweightConnector, LightweightFileSystem, SlamDB}
 import slamdata.Predef._
 
 import org.http4s.client.blaze.PooledHttp1Client
@@ -44,5 +45,14 @@ final class S3LWC(jsonParsing: S3JsonParsing) extends LightweightConnector {
       val \/-(httpUri) = Uri.fromString(uri.value)
       (new S3LWFS(jsonParsing, httpUri, client), client.shutdown)
     })
+}
 
+object S3JsonArray extends SlamDB {
+  val Type: FileSystemType = FileSystemType("s3array")
+  val lwc: LightweightConnector = new S3LWC(S3JsonParsing.JsonArray)
+}
+
+object S3LineDelimited extends SlamDB {
+  val Type: FileSystemType = FileSystemType("s3linedelim")
+  val lwc: LightweightConnector = new S3LWC(S3JsonParsing.LineDelimited)
 }

--- a/lwc/src/main/scala/quasar/physical/s3/S3LWFS.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/S3LWFS.scala
@@ -37,6 +37,8 @@ final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
     def >+>[A](opt: Option[A], f: (B, A) => B): B = opt.fold(self)(f(self, _))
   }
 
+  private type APath = Path[Path.Abs, Any, Path.Sandboxed]
+
   private def aPathToObjectPrefix(apath: APath): Option[String] = {
     // don't provide prefix if listing the top-level,
     // otherwise drop the first /
@@ -44,12 +46,6 @@ final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
       Path.posixCodec.printPath(apath).drop(1) // .replace("/", "%2F")
     }
   }
-
-  private def documentToPathSegments(document: xml.Elem): Option[Set[PathSegment]] = {
-    None
-  }
-
-  private type APath = Path[Path.Abs, Any, Path.Sandboxed]
 
   private def s3NameToPath(name: String): Option[APath] = {
     val unsandboxed =
@@ -103,7 +99,7 @@ final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
       client.status(request).flatMap {
         case Status.Ok => true.point[Task]
         case Status.NotFound => false.point[Task]
-        case s => Task.fail(new Exception("Unexpected status $s"))
+        case s => Task.fail(new Exception(s"Unexpected status $s"))
       }
     }
   }

--- a/lwc/src/main/scala/quasar/physical/s3/S3LWFS.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/S3LWFS.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.s3
+
+import quasar.Data
+import quasar.contrib.pathy._
+import quasar.mimir.LightweightFileSystem
+import slamdata.Predef._
+
+import fs2.Stream
+import org.http4s.client._
+import org.http4s.scalaxml.{xml => xmlDecoder}
+import org.http4s.{Method, Request, Status, Uri}
+import pathy.Path
+import scala.xml
+
+import scalaz.Scalaz._
+import scalaz.concurrent.Task
+
+final class S3LWFS(uri: Uri, client: Client) extends LightweightFileSystem {
+
+  implicit private final class optApplyOps[B](self: B) {
+    def >+>[A](opt: Option[A], f: (B, A) => B): B = opt.fold(self)(f(self, _))
+  }
+
+  private def aPathToObjectPrefix(apath: APath): Option[String] = {
+    // don't provide prefix if listing the top-level,
+    // otherwise drop the first /
+    (apath != Path.rootDir).option {
+      Path.posixCodec.printPath(apath).drop(1) // .replace("/", "%2F")
+    }
+  }
+
+  private def documentToPathSegments(document: xml.Elem): Option[Set[PathSegment]] = {
+    None
+  }
+
+  private type APath = Path[Path.Abs, Any, Path.Sandboxed]
+
+  private def s3NameToPath(name: String): Option[APath] = {
+    val unsandboxed =
+      Path.posixCodec.parsePath[Option[Path[Path.Abs, Any, Path.Unsandboxed]]](
+        _ => none,
+        _.some,
+        _ => none,
+        _.some
+      )("/" + name)
+    unsandboxed.map(unsafeSandboxAbs)
+  }
+
+  // this is a recursive listing which filters out children that aren't direct children.
+  // it also will only list 100 keys (and 1000 maximum, and it needs pagination to do more)
+  // that's 100 *recursively listed* keys, which means we could conceivably list *none*
+  // of the direct children of a folder, depending on the order AWS sends them in.
+  def children(dir: ADir): Task[Option[Set[PathSegment]]] = {
+    val objectPrefix = aPathToObjectPrefix(dir)
+    val maxKeys = 100
+    val queryUri = ((uri / "") +?
+      ("list-type", 2)) >+>[String]
+      (objectPrefix, _ +? ("prefix", _))
+    Task.suspend {
+      for {
+        // TODO: better error handling, please
+        topLevelElem <- client.expect[xml.Elem](queryUri)
+        children <- Task.delay {
+          // TODO: here too, these xml ops can all fail
+          (topLevelElem \\ "Contents").map(e => (e \\ "Key").text).toList
+        }
+        childPaths <- children.traverse(s3NameToPath).fold[Task[List[APath]]](Task.fail(new Exception("Failed to parse S3 API response")))(Task.now)
+        result =
+        if (!childPaths.element(dir)) None
+        else Some(
+          childPaths.filter(path =>
+            // AWS includes the folder itself in the returned results if it exists, so we have to remove it.
+            // same goes for files in folders *below* the listed folder.
+            path =/= dir && Path.parentDir(path) === Some(dir))
+          .flatMap(Path.peel(_).toList)
+          .map(_._2).toSet)
+      } yield result
+    }
+  }
+
+  def exists(file: AFile): Task[Boolean] = {
+    val objectPath = Path.posixCodec.printPath(file).drop(1)
+    Task.suspend {
+      val queryUri = uri / objectPath
+      val request = Request(uri = queryUri, method = Method.HEAD)
+      println(queryUri)
+      client.status(request).flatMap {
+        case Status.Ok => true.point[Task]
+        case Status.NotFound => false.point[Task]
+        case s => Task.fail(new Exception("Unexpected status $s"))
+      }
+    }
+  }
+
+  private def streamingParse(stream: scalaz.stream.Process[Task, String]): Stream[Task, Data] = {
+    Stream.empty
+  }
+
+  def read(file: AFile): Task[Option[Stream[Task, Data]]] = {
+    val objectPath = Path.posixCodec.printPath(file).drop(1)
+    val queryUri = uri / objectPath
+    // client.streaming(queryUri)(resp => resp.body)
+    ???
+  }
+}

--- a/lwc/src/main/scala/quasar/physical/s3/impl/children.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/impl/children.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.s3.impl
+
+import slamdata.Predef._
+
+import org.http4s.client.Client
+import org.http4s.Uri
+import org.http4s.scalaxml.{xml => xmlDecoder}
+import pathy.Path
+import quasar.contrib.pathy._
+import scala.xml
+import scalaz.concurrent.Task
+import scalaz.std.option._
+import scalaz.std.list._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+import scalaz.syntax.std.option._
+import scalaz.syntax.traverse._
+
+object children {
+  private def aPathToObjectPrefix(apath: APath): Option[String] = {
+    // don't provide prefix if listing the top-level,
+    // otherwise drop the first /
+    (apath != Path.rootDir).option {
+      Path.posixCodec.printPath(apath).drop(1) // .replace("/", "%2F")
+    }
+  }
+
+  private def s3NameToPath(name: String): Option[APath] = {
+    val unsandboxed: Option[Path[Path.Abs, Any, Path.Unsandboxed]] =
+      Path.posixCodec.parsePath(
+        _ => none,
+        _.some,
+        _ => none,
+        _.some
+      )("/" + name)
+    unsandboxed.map(unsafeSandboxAbs)
+  }
+
+  implicit private final class optApplyOps[B](self: B) {
+    def >+>[A](opt: Option[A], f: (B, A) => B): B = opt.fold(self)(f(self, _))
+  }
+
+  // this is a recursive listing which filters out children that aren't direct children.
+  // it also will only list 100 keys (and 1000 maximum, and it needs pagination to do more)
+  // that's 100 *recursively listed* keys, which means we could conceivably list *none*
+  // of the direct children of a folder, depending on the order AWS sends them in.
+  def apply(client: Client, uri: Uri, dir: ADir): Task[Option[Set[PathSegment]]] = {
+    val objectPrefix = aPathToObjectPrefix(dir)
+    val maxKeys = 100
+    val queryUri = ((uri / "") +?
+      ("list-type", 2)) >+>[String]
+      (objectPrefix, _ +? ("prefix", _))
+    Task.suspend {
+      for {
+        // TODO: better error handling, please
+        topLevelElem <- client.expect[xml.Elem](queryUri)
+        children <- Task.delay {
+          // TODO: here too, these xml ops can all fail
+          (topLevelElem \\ "Contents").map(e => (e \\ "Key").text).toList
+        }
+        // TODO: and here too
+        childPaths <- children.traverse(s3NameToPath)
+          .cata(Task.now, Task.fail(new Exception("Failed to parse S3 API response")))
+        // TODO: I want to log it when we have `childPaths.nonEmpty` but `!childPaths.element(dir)`.
+        result =
+        if (!childPaths.element(dir)) None
+        else Some(
+          childPaths
+            .filter(path =>
+              // AWS includes the folder itself in the returned results if it exists, so we have to remove it.
+              // same goes for files in folders *below* the listed folder.
+              path =/= dir && Path.parentDir(path) === Some(dir))
+            // TODO: report an error when `Path.peel` fails, that's nonsense
+            .flatMap(Path.peel(_).toList)
+            // TODO: report an error if there are duplicates
+            .map(_._2).toSet)
+      } yield result
+    }
+  }
+
+}

--- a/lwc/src/main/scala/quasar/physical/s3/impl/children.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/impl/children.scala
@@ -79,7 +79,7 @@ object children {
           .cata(Task.now, Task.fail(new Exception("Failed to parse S3 API response")))
         // TODO: I want to log it when we have `childPaths.nonEmpty` but `!childPaths.element(dir)`.
         result =
-        if (!childPaths.element(dir)) None
+        if (dir =/= Path.rootDir && !childPaths.element(dir)) None
         else Some(
           childPaths
             .filter(path =>

--- a/lwc/src/main/scala/quasar/physical/s3/impl/exists.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/impl/exists.scala
@@ -33,7 +33,7 @@ object exists {
       client.status(request).flatMap {
         case Status.Ok => Task.now(true)
         case Status.NotFound => Task.now(false)
-        case s => Task.fail(new Exception(s"Unexpected status $s"))
+        case s => Task.fail(new Exception("Unexpected status returned during `exists` call: $s"))
       }
     }
   }

--- a/lwc/src/main/scala/quasar/physical/s3/impl/package.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/impl/package.scala
@@ -16,22 +16,6 @@
 
 package quasar.physical.s3
 
-import quasar.Data
-import quasar.contrib.pathy._
-import quasar.mimir.LightweightFileSystem
-import slamdata.Predef._
-
-import fs2.Stream
-import org.http4s.client.Client
-import org.http4s.Uri
-import scalaz.concurrent.Task
-
-final class S3LWFS(jsonParsing: S3JsonParsing, uri: Uri, client: Client) extends LightweightFileSystem {
-
-  def children(dir: ADir): Task[Option[Set[PathSegment]]] = impl.children(client, uri, dir)
-
-  def read(file: AFile): Task[Option[Stream[Task, Data]]] = impl.read(jsonParsing, client, uri, file)
-
-  def exists(file: AFile): Task[Boolean] = impl.exists(client, uri, file)
-
+package object impl {
+  private type APath = pathy.Path[pathy.Path.Abs, scala.Any, pathy.Path.Sandboxed]
 }

--- a/lwc/src/main/scala/quasar/physical/s3/impl/read.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/impl/read.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.s3.impl
+
+import quasar.Data
+import quasar.contrib.pathy._
+import quasar.physical.s3.S3JsonParsing
+import slamdata.Predef._
+
+import fs2.{Pipe, Stream}
+import io.circe.Json
+import org.http4s.client._
+import org.http4s.{Request, Response, Status, Uri}
+import pathy.Path
+import scalaz.Scalaz._
+import scalaz.concurrent.Task
+import scodec.bits.ByteVector
+
+object read {
+
+  private def circePipe[F[_]](jsonParsing: S3JsonParsing): Pipe[F, String, Json] = jsonParsing match {
+    case S3JsonParsing.JsonArray => io.circe.fs2.stringArrayParser[F]
+    case S3JsonParsing.LineDelimited => io.circe.fs2.stringStreamParser[F]
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  private def circeJsonToData(json: Json): Data = {
+    json.fold(
+      Data.Null,
+      Data.Bool,
+      n => Data.Dec(n.toBigDecimal.getOrElse(n.toDouble)),
+      Data.Str,
+      js => Data.Arr(js.map(circeJsonToData)(scala.collection.breakOut)),
+      js => Data.Obj(ListMap(js.toList.map { case (k, v) => k -> circeJsonToData(v) }: _*))
+    )
+  }
+
+  private def streamRequestThroughFs2[A](client: Client, req: Request)(f: Response => Stream[Task, A]): Task[Option[Stream[Task, A]]] = {
+    client.open(req).flatMap {
+      case DisposableResponse(response, dispose) =>
+        response.status match {
+          case Status.NotFound => Task.now(none)
+          case Status.Ok => Task.now(f(response).onComplete(Stream.eval_(dispose)).some)
+          case s => Task.fail(new Exception(s"Unexpected status $s"))
+        }
+    }
+  }
+
+  def apply(jsonParsing: S3JsonParsing, client: Client, uri: Uri, file: AFile): Task[Option[Stream[Task, Data]]] = {
+    val objectPath = Path.posixCodec.printPath(file).drop(1)
+    val queryUri = uri / objectPath
+    val request = Request(uri = queryUri)
+    val circeJsonPipe = circePipe[Task](jsonParsing)
+    streamRequestThroughFs2(client, request) { resp =>
+      val asFs2: Stream[Task, ByteVector] = spinoco.scalaz.stream.fs2Conversion.processToFs2(resp.body)
+      val asStrings: Stream[Task, String] = asFs2.evalMap(_.decodeUtf8.fold(Task.fail, Task.now))
+      val asJson: Stream[Task, Json] = asStrings.through(circeJsonPipe)
+      val asData: Stream[Task, Data] = asJson.map(circeJsonToData)
+      asData
+    }
+  }
+}

--- a/lwc/src/main/scala/quasar/physical/s3/package.scala
+++ b/lwc/src/main/scala/quasar/physical/s3/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical
+
+import scalaz.concurrent.Task
+
+package object s3 {
+
+  implicit val fs2MonadTask: fs2.util.Monad[Task] = new fs2.util.Monad[Task] {
+    def flatMap[A, B](a: Task[A])(f: A => Task[B]): Task[B] = a.flatMap(f)
+    def pure[A](a: A): Task[A] = Task.now(a)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,8 @@ object Dependencies {
   private val fs2Version          = "0.9.6"
   private val fs2ScalazVersion    = "0.2.0"
 
+  val circeFs2Version             = "0.9.0"
+
   private val quasarVersion       = "38.2.3-f3f05e7"
 
   def lwc = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,8 +32,9 @@ object Dependencies {
   private val deloreanVersion     = "1.2.42-scalaz-7.2"
   private val fs2Version          = "0.9.6"
   private val fs2ScalazVersion    = "0.2.0"
+  private val scalaXmlVersion     = "1.1.0"
 
-  val circeFs2Version             = "0.9.0"
+  private val circeFs2Version     = "0.9.0"
 
   private val quasarVersion       = "38.2.3-f3f05e7"
 
@@ -77,12 +78,13 @@ object Dependencies {
     "org.http4s"                 %% "http4s-argonaut"           % http4sVersion,
     "org.http4s"                 %% "http4s-client"             % http4sVersion,
     "org.http4s"                 %% "http4s-server"             % http4sVersion,
+    "org.http4s"                 %% "http4s-scala-xml"          % http4sVersion,
     "org.http4s"                 %% "http4s-blaze-server"       % http4sVersion,
     "org.http4s"                 %% "http4s-blaze-client"       % http4sVersion,
-    "com.propensive"             %% "rapture-json"              % raptureVersion                       % Test,
-    "com.propensive"             %% "rapture-json-json4s"       % raptureVersion                       % Test,
     "eu.timepit"                 %% "refined-scalacheck"        % refinedVersion                       % Test,
-    "org.quasar-analytics"       %% "quasar-mimir-internal"     % quasarVersion
+    "org.quasar-analytics"       %% "quasar-mimir-internal"     % quasarVersion,
+    "org.scala-lang.modules"     %% "scala-xml"                 % scalaXmlVersion,
+    "io.circe"                   %% "circe-fs2"                 % circeFs2Version
   )
 
   def it = lwc ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,10 +34,9 @@ object Dependencies {
   private val fs2ScalazVersion    = "0.2.0"
   private val scalaXmlVersion     = "1.1.0"
 
-  private val circeFs2Version     = "0.9.0"
+  private val circeJawnVersion     = "0.8.0"
 
   private val quasarVersion       = "38.2.3-f3f05e7"
-  private val shimsVersion        = "1.2"
 
   def lwc = Seq(
     "com.slamdata"               %% "slamdata-predef"           % "0.0.4",
@@ -85,8 +84,7 @@ object Dependencies {
     "eu.timepit"                 %% "refined-scalacheck"        % refinedVersion                       % Test,
     "org.quasar-analytics"       %% "quasar-mimir-internal"     % quasarVersion,
     "org.scala-lang.modules"     %% "scala-xml"                 % scalaXmlVersion,
-    "io.circe"                   %% "circe-fs2"                 % circeFs2Version,
-    "com.codecommit"             %% "shims"                     % shimsVersion
+    "io.circe"                   %% "circe-jawn"                % circeJawnVersion
   )
 
   def it = lwc ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,6 +37,7 @@ object Dependencies {
   private val circeFs2Version     = "0.9.0"
 
   private val quasarVersion       = "38.2.3-f3f05e7"
+  private val shimsVersion        = "1.2"
 
   def lwc = Seq(
     "com.slamdata"               %% "slamdata-predef"           % "0.0.4",
@@ -84,7 +85,8 @@ object Dependencies {
     "eu.timepit"                 %% "refined-scalacheck"        % refinedVersion                       % Test,
     "org.quasar-analytics"       %% "quasar-mimir-internal"     % quasarVersion,
     "org.scala-lang.modules"     %% "scala-xml"                 % scalaXmlVersion,
-    "io.circe"                   %% "circe-fs2"                 % circeFs2Version
+    "io.circe"                   %% "circe-fs2"                 % circeFs2Version,
+    "com.codecommit"             %% "shims"                     % shimsVersion
   )
 
   def it = lwc ++ Seq(

--- a/scripts/travis_tag
+++ b/scripts/travis_tag
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ||
+      ("$TRAVIS_BRANCH" != "master" && "$TRAVIS_BRANCH" != backport/*) ]]
+then exit
+fi
+
+git config --global user.email "builds@travis-ci.com"
+git config --global user.name "Travis CI"
+TAG=v$VERSION
+git tag $TAG -a -m "Quasar S3 Connector $VERSION"
+git push origin $TAG
+export TRAVIS_TAG=v$VERSION

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,1 @@
+export VERSION=$(sed 's/.*"\(.*\)"/\1/' version.sbt)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "36.0.0"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
Depends on #1. But after this, let it be known that we have liftoff.

```
~/w/s/s3-tests java -jar quasar-repl-assembly-38.2.3-f3f05e7.jar --backend:quasar.physical.s3.S3LineDelimited\$=plugins/quasar-s3-assembly-0.0.1.jar
Configuration file '/home/nope/.config/quasar/quasar-config.json' not found, using default configuration.
log4j:WARN No appenders could be found for logger (com.zaxxer.hikari.HikariConfig).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Using metastore: jdbc:h2:/home/nope/.config/quasar/quasar-metastore.db
(v38.2.3-f3f05e7) 💪 $ cd s3test
(v38.2.3-f3f05e7) 💪 $ select * from `extraSmallZips.data`
QScript (Optimized):
Subset(Take)
├─ Unreferenced
├─ From
│  ╰─ ShiftedRead(/extraSmallZips.data, ExcludeId)
╰─ Count
   ╰─ Map
      ├─ Unreferenced
      ╰─ Constant(Int(10))

Query time: 1.0s
 city           | state | pop    | _id    | loc[0]      | loc[1]     |
----------------|-------|--------|--------|-------------|------------|
 AGAWAM         | MA    |  15338 | 01001  |  -72.622739 |  42.070206 |
 CUSHMAN        | MA    |  36963 | 01002  |   -72.51565 |  42.377017 |
 BARRE          | MA    |   4546 | 01005  |  -72.108354 |  42.409698 |
 BLANDFORD      | MA    |   1240 | 01008  |  -72.936114 |  42.182949 |
 BRIMFIELD      | MA    |   3706 | 01010  |  -72.188455 |  42.116543 |
 CHESTER        | MA    |   1688 | 01011  |  -72.988761 |  42.279421 |
 WESTOVER AFB   | MA    |   1764 | 01022  |  -72.558657 |  42.196672 |
 CUMMINGTON     | MA    |   1484 | 01026  |  -72.905767 |  42.435296 |
 MOUNT TOM      | MA    |  16864 | 01027  |  -72.679921 |  42.264319 |
 FEEDING HILLS  | MA    |  11985 | 01030  |  -72.675077 |   42.07182 |
(v38.2.3-f3f05e7) 💪 $
Exiting...
```